### PR TITLE
Type casting

### DIFF
--- a/Model/Account.php
+++ b/Model/Account.php
@@ -114,7 +114,7 @@ abstract class Account
     
     public function setSubscriptionDiscount($v)
     {
-        $this->subscriptionDiscount = $v;
+        $this->subscriptionDiscount = (float)$v;
     }
     
     public function hasFullSubscriptionDiscount()


### PR DESCRIPTION
An SQL error will occur if administrator won't fill a "Discount" field.
This patch is forcing to cast to a float type (empty string -> 0).

I'm not 100% sure about this patch, maybe I'm missing something.
What do you think?
@freakphp @wujashek
